### PR TITLE
Exclude files when building the site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,3 +27,14 @@ scripts: []
 
 # Build settings
 markdown: kramdown
+
+# Exlude files from being present in the build site
+exclude:
+- ".gitignore"
+- Gemfile
+- Gemfile.lock
+- README.md
+- LICENSE
+- package.json
+- node_modules
+- README.md


### PR DESCRIPTION
This commit adds a list of files to the configuration that should be exluded from site builds. This is creating a problem on Federalist where the node modules are being built into the site.

This was noticed when sites weren't updating because they were timing out after taking a long time to upload.